### PR TITLE
Solve issue #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ myMaxCube.getConnection().then(function () {
 ```
 ### close()
 Closes the connection to the Max! Cube immediately (when active).
+### disconnect()
+Send **q** command to the Max! Cube and Cube will close a connection.
 ### getCommStatus()
 Returns the last known communication status (duty cycle & free memory slots).
 ### getDevices()

--- a/maxcube-lowlevel.js
+++ b/maxcube-lowlevel.js
@@ -75,7 +75,9 @@ function connect () {
 }
 
 function close () {
-  this.socket.destroy();
+  if (this.socket) {
+    this.socket.destroy();
+  }
 }
 
 function send (dataStr) {

--- a/maxcube.js
+++ b/maxcube.js
@@ -30,7 +30,6 @@ function MaxCube(ip, port) {
   this.configCache = {};
 
   this.maxCubeLowLevel.on('closed', function () {
-    self.initialised = false;
     self.emit('closed');
   });
 
@@ -284,6 +283,10 @@ MaxCube.prototype.setSchedule = function(rf_address, room_id, weekday, temperatu
 
 MaxCube.prototype.close = function() {
   this.maxCubeLowLevel.close();
+};
+
+MaxCube.prototype.disconnect = function() {
+  send.call(this, 'q:\r\n');
 };
 
 module.exports = MaxCube;


### PR DESCRIPTION
To solve issue #3 
Don't set **initialised** to false on "closed" event.
Added **disconnect()** function - send "q:\r\n" and cube will close a connection.