### PR TITLE
Added timeout support

### DIFF
--- a/maxcube-lowlevel.js
+++ b/maxcube-lowlevel.js
@@ -45,6 +45,13 @@ function initSocket () {
     });
   });
 
+  // If send has been called with timeout, this event will be emitted if there is no activity on the stream for the configured timeout
+  this.socket.on( 'timeout', function() {
+    console.error( 'Maxcube: Connection timed out.' );
+    // Timeout indicates a problem with the Cube, so emit error
+    self.emit( 'error', new Error( 'Maxcube: Connection timed out.' ) );
+  } );
+
   this.socket.on('close', function() {
     self.isConnected = false;
     self.emit('closed');
@@ -52,7 +59,7 @@ function initSocket () {
 
   this.socket.on('error', function(err) {
     console.error(err);
-      self.emit('error', err);
+    self.emit('error', err);
   });
 }
 
@@ -80,8 +87,11 @@ function close () {
   }
 }
 
-function send (dataStr) {
+// Can be called with and without timeout
+function send( dataStr, timeout=0 ) {
   this.socket.write(dataStr);
+  // Setting timeout to 0 disables the timeout
+  this.socket.setTimeout( timeout );
 }
 
 function isConnected () {

--- a/maxcube-lowlevel.js
+++ b/maxcube-lowlevel.js
@@ -52,7 +52,7 @@ function initSocket () {
 
   this.socket.on('error', function(err) {
     console.error(err);
-    self.emit('error');
+      self.emit('error', err);
   });
 }
 

--- a/maxcube-lowlevel.js
+++ b/maxcube-lowlevel.js
@@ -23,13 +23,16 @@ function initSocket () {
   var self = this;
   var previousPacketData = '';
 
-	this.socket.on('data', function(dataBuff) {
+  this.socket.on('data', function(dataBuff) {
     var dataStr = dataBuff.toString('utf-8');
 
     if (!dataStr.endsWith('\r\n')) {
       previousPacketData = dataStr;
       return;
     }
+
+    // Delete timeout after data has been received
+    self.socket.setTimeout( 0 );
 
     dataStr = previousPacketData + dataStr;
     previousPacketData = '';

--- a/maxcube.js
+++ b/maxcube.js
@@ -160,7 +160,7 @@ MaxCube.prototype.getCommStatus = function() {
   return this.commStatus;
 }
 
-MaxCube.prototype.getDeviceStatus = function(rf_address, timeout=0) {
+MaxCube.prototype.getDeviceStatus = function(rf_address=undefined, timeout=0) {
   checkInitialised.call(this);
 
   return send.call(this, 'l:\r\n', 'L', timeout).then(function (devices) {

--- a/maxcube.js
+++ b/maxcube.js
@@ -30,9 +30,11 @@ function MaxCube(ip, port) {
   this.configCache = {};
 
   this.maxCubeLowLevel.on('closed', function () {
-    self.waitForCommandResolver.reject( 'closed' );
-    self.waitForCommandType = undefined;
-    self.waitForCommandResolver = undefined;
+    if( self.waitForCommandResolver ) {
+      self.waitForCommandResolver.reject( 'closed' );
+      self.waitForCommandType = undefined;
+      self.waitForCommandResolver = undefined;
+    }
     self.emit('closed');
   });
 
@@ -48,9 +50,11 @@ function MaxCube(ip, port) {
 
   this.maxCubeLowLevel.on('error', function( err ) {
     self.initialised = false;
-    self.waitForCommandResolver.reject( 'closed' );
-    self.waitForCommandType = undefined;
-    self.waitForCommandResolver = undefined;
+    if( self.waitForCommandResolver ) {
+      self.waitForCommandResolver.reject( 'closed' );
+      self.waitForCommandType = undefined;
+      self.waitForCommandResolver = undefined;
+    }
     self.emit('error', err);
   });
 

--- a/maxcube.js
+++ b/maxcube.js
@@ -30,6 +30,9 @@ function MaxCube(ip, port) {
   this.configCache = {};
 
   this.maxCubeLowLevel.on('closed', function () {
+    self.waitForCommandResolver.reject( 'closed' );
+    self.waitForCommandType = undefined;
+    self.waitForCommandResolver = undefined;
     self.emit('closed');
   });
 
@@ -45,6 +48,9 @@ function MaxCube(ip, port) {
 
   this.maxCubeLowLevel.on('error', function( err ) {
     self.initialised = false;
+    self.waitForCommandResolver.reject( 'closed' );
+    self.waitForCommandType = undefined;
+    self.waitForCommandResolver = undefined;
     self.emit('error', err);
   });
 

--- a/maxcube.js
+++ b/maxcube.js
@@ -139,7 +139,7 @@ function send( command, replyCommandType, timeout=0 ) {
       self.maxCubeLowLevel.send( command, timeout );
       return waitForCommand.call(self, replyCommandType);
     } else {
-      // Don't set a timeout on commands that don't except a reply.
+      // Don't set a timeout on commands that don't expect a reply.
       self.maxCubeLowLevel.send( command, 0 );
       return Promise.resolve();
     }
@@ -160,10 +160,10 @@ MaxCube.prototype.getCommStatus = function() {
   return this.commStatus;
 }
 
-MaxCube.prototype.getDeviceStatus = function(rf_address) {
+MaxCube.prototype.getDeviceStatus = function(rf_address, timeout=0) {
   checkInitialised.call(this);
 
-  return send.call(this, 'l:\r\n', 'L').then(function (devices) {
+  return send.call(this, 'l:\r\n', 'L', timeout).then(function (devices) {
     if (rf_address) {
       return devices.filter(function(device) {
         return device.rf_address === rf_address;
@@ -246,36 +246,36 @@ MaxCube.prototype.flushDeviceCache = function() {
   return send.call(this, 'm:\r\n');
 };
 
-MaxCube.prototype.resetError = function(rf_address) {
+MaxCube.prototype.resetError = function(rf_address, timeout=0) {
   checkInitialised.call(this);
 
-  return send.call(this, MaxCubeCommandFactory.generateResetCommand(rf_address, this.deviceCache[rf_address].room_id), 'S');
+  return send.call(this, MaxCubeCommandFactory.generateResetCommand(rf_address, this.deviceCache[rf_address].room_id), 'S', timeout);
 };
 
-MaxCube.prototype.sayHello = function() {
+MaxCube.prototype.sayHello = function(timeout=0) {
   checkInitialised.call(this);
 
-  return send.call(this, 'h:\r\n', 'H').then(function (res) {
+  return send.call(this, 'h:\r\n', 'H', timeout).then(function (res) {
     self.commStatus.duty_cycle = res.duty_cycle;
     self.commStatus.free_memory_slots = res.free_memory_slots;
     return true;
   });
 };
 
-MaxCube.prototype.setTemperature = function(rf_address, degrees, mode, untilDate) {
+MaxCube.prototype.setTemperature = function(rf_address, degrees, mode, untilDate, timeout=0) {
   checkInitialised.call(this);
 
   var self = this;
   degrees = Math.max(2, degrees);
   var command = MaxCubeCommandFactory.generateSetTemperatureCommand (rf_address, this.deviceCache[rf_address].room_id, mode || 'MANUAL', degrees, untilDate);
-  return send.call(this, command, 'S').then(function (res) {
+  return send.call(this, command, 'S', timeout).then(function (res) {
     self.commStatus.duty_cycle = res.duty_cycle;
     self.commStatus.free_memory_slots = res.free_memory_slots;
     return res.accepted;
   });
 };
 
-MaxCube.prototype.setSchedule = function(rf_address, room_id, weekday, temperaturesArray, timesArray) {
+MaxCube.prototype.setSchedule = function(rf_address, room_id, weekday, temperaturesArray, timesArray, timeout=0) {
   // weekday:           0=mo,1=tu,..,6=su
   // temperaturesArray: [19.5,21,..] degrees Celsius (max 7)
   // timesArray:        ['HH:mm',..] 24h format (max 7, same amount as temperatures)
@@ -286,7 +286,7 @@ MaxCube.prototype.setSchedule = function(rf_address, room_id, weekday, temperatu
   var self = this;
 
   var command = MaxCubeCommandFactory.generateSetDayProgramCommand (rf_address, room_id, weekday, temperaturesArray, timesArray);
-  return send.call(this, command, 'S').then(function (res) {
+  return send.call(this, command, 'S', timeout).then(function (res) {
     self.commStatus.duty_cycle = res.duty_cycle;
     self.commStatus.free_memory_slots = res.free_memory_slots;
     return res.accepted;

--- a/maxcube.js
+++ b/maxcube.js
@@ -131,14 +131,16 @@ function waitForCommand (commandType) {
   return this.waitForCommandResolver.promise;
 }
 
-function send (command, replyCommandType) {
+function send( command, replyCommandType, timeout=0 ) {
   var self = this;
   return self.getConnection().then(function () {
-    self.maxCubeLowLevel.send(command);
-
-    if (replyCommandType) {
+    if( replyCommandType ) {
+      // On commands with expected reply set a timeout if requested
+      self.maxCubeLowLevel.send( command, timeout );
       return waitForCommand.call(self, replyCommandType);
     } else {
+      // Don't set a timeout on commands that don't except a reply.
+      self.maxCubeLowLevel.send( command, 0 );
       return Promise.resolve();
     }
   });

--- a/maxcube.js
+++ b/maxcube.js
@@ -43,9 +43,9 @@ function MaxCube(ip, port) {
     }
   });
 
-  this.maxCubeLowLevel.on('error', function () {
+  this.maxCubeLowLevel.on('error', function( err ) {
     self.initialised = false;
-    self.emit('error');
+    self.emit('error', err);
   });
 
   this.maxCubeLowLevel.on('command', function (command) {


### PR DESCRIPTION
Fixes #8 

Add timeout support for commands with expected reply.
Non-reply commands do not set a timeout.
If no data has been received after the timeout has been triggered after a send command, the promise is rejected and an error event it emitted.

This solution is not perfect, because if a non-reply command is issues before the answer for a previous reply command has been received (or the timeout elapsed), the timeout is reset and the lack of answer to the first command is never reported.
But I think that's an sufficiently edgy case to ignore it for the moment.

Also some cleanup and improvements in error handling.